### PR TITLE
Fix edge case in logout

### DIFF
--- a/app/src/main/java/com/rubenarriazu/paranoid/ui/nav_menu/Settings.java
+++ b/app/src/main/java/com/rubenarriazu/paranoid/ui/nav_menu/Settings.java
@@ -292,11 +292,9 @@ public class Settings extends AppCompatActivity {
         call.enqueue(new Callback<ResponseBody>() {
             @Override
             public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
-                if (response.isSuccessful()) {
-                    flushStoredCredentials(getApplicationContext());
-                    var landingPageIntent = new Intent(getApplicationContext(), MainActivity.class);
-                    startActivity(landingPageIntent);
-                }
+                flushStoredCredentials(getApplicationContext());
+                var landingPageIntent = new Intent(getApplicationContext(), MainActivity.class);
+                startActivity(landingPageIntent);
             }
 
             @Override


### PR DESCRIPTION
In case has not the correct token cannot logout. This patch
fixes the described bug.
